### PR TITLE
Android security 11.0.0 release 66

### DIFF
--- a/src/com/android/providers/media/util/FileUtils.java
+++ b/src/com/android/providers/media/util/FileUtils.java
@@ -975,7 +975,9 @@ public class FileUtils {
     }
 
     public static @Nullable String extractRelativePath(@Nullable String data) {
+        data = getCanonicalPath(data);
         if (data == null) return null;
+
         final Matcher matcher = PATTERN_RELATIVE_PATH.matcher(data);
         if (matcher.find()) {
             final int lastSlash = data.lastIndexOf('/');
@@ -1377,5 +1379,17 @@ public class FileUtils {
             }
         }
         return status;
+    }
+
+    @Nullable
+    private static String getCanonicalPath(@Nullable String path) {
+        if (path == null) return null;
+
+        try {
+            return new File(path).getCanonicalPath();
+        } catch (IOException e) {
+            Log.d(TAG, "Unable to get canonical path from invalid data path: " + path, e);
+            return null;
+        }
     }
 }

--- a/tests/src/com/android/providers/media/util/FileUtilsTest.java
+++ b/tests/src/com/android/providers/media/util/FileUtilsTest.java
@@ -459,7 +459,15 @@ public class FileUtilsTest {
                     extractRelativePath(prefix + "DCIM/foo.jpg"));
             assertEquals("DCIM/My Vacation/",
                     extractRelativePath(prefix + "DCIM/My Vacation/foo.jpg"));
+            assertEquals("Pictures/",
+                    extractRelativePath(prefix + "DCIM/../Pictures/.//foo.jpg"));
+            assertEquals("/",
+                    extractRelativePath(prefix + "DCIM/Pictures/./..//..////foo.jpg"));
+            assertEquals("Android/data/",
+                    extractRelativePath(prefix + "DCIM/foo.jpg/.//../../Android/data/poc"));
         }
+
+        assertEquals(null, extractRelativePath("/sdcard/\\\u0000"));
     }
 
     @Test


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r66' of https://android.googlesource.com/platform/packages/providers/MediaProvider into arrow-11.0

Android security 11.0.0 release 66
Tag: https://android.googlesource.com/platform/packages/providers/MediaProvider/+/refs/tags/android-security-11.0.0_r66

Merge cherrypicks of ['googleplex-android-review.googlesource.com/20942350'] into security-aosp-rvc-release.

Change-Id: [I6ac42e7f7e0f765de5e378fe999da5fd6477386e](https://android-review.googlesource.com/#/q/I6ac42e7f7e0f765de5e378fe999da5fd6477386e)