### PR TITLE
Android security 11.0.0 release 71

### DIFF
--- a/src/com/android/providers/media/util/FileUtils.java
+++ b/src/com/android/providers/media/util/FileUtils.java
@@ -1138,8 +1138,16 @@ public class FileUtils {
         values.remove(MediaColumns.BUCKET_ID);
         values.remove(MediaColumns.BUCKET_DISPLAY_NAME);
 
-        final String data = values.getAsString(MediaColumns.DATA);
+        String data = values.getAsString(MediaColumns.DATA);
         if (TextUtils.isEmpty(data)) return;
+
+        try {
+            data = new File(data).getCanonicalPath();
+            values.put(MediaColumns.DATA, data);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Invalid file path:%s in request.", data));
+        }
 
         final File file = new File(data);
         final File fileLower = new File(data.toLowerCase(Locale.ROOT));


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r71' of https://android.googlesource.com/platform/packages/providers/MediaProvider into arrow-11.0

Android security 11.0.0 release 71
Tag: https://android.googlesource.com/platform/packages/providers/MediaProvider/+/refs/tags/android-security-11.0.0_r71

Merge cherrypicks of ['googleplex-android-review.googlesource.com/23764857', 'googleplex-android-review.googlesource.com/23916075'] into security-aosp-rvc-release.

Change-Id: [Icce5f61755455d0853ef651984e8ff29435c36ed](https://android-review.googlesource.com/#/q/Icce5f61755455d0853ef651984e8ff29435c36ed)